### PR TITLE
Fixed black status bar in launch image and switcher

### DIFF
--- a/layout/Applications/CrashReporter.app/Info.plist
+++ b/layout/Applications/CrashReporter.app/Info.plist
@@ -63,8 +63,11 @@
         <key>DTPlatformName</key>
         <string>iphoneos</string>
 
+        <key>DTPlatformVersion</key>
+        <string>7.0</string>
+
         <key>DTSDKName</key>
-        <string>iphoneos3.0</string>
+        <string>iphoneos7.1</string>
 
         <key>LSRequiresIPhoneOS</key>
         <string>1</string>


### PR DESCRIPTION
Starting with iOS 7, a key named DTPlatformVersion is expected in Info.plist with a value of 7.0 or greater. If not found, SpringBoard falls back to displaying some ugly iOS 6 artifacts. Thanks for updating CrashReporter!
