### PR TITLE
Do not notify about SIMULATED Crash Reports

### DIFF
--- a/notifier/main.m
+++ b/notifier/main.m
@@ -78,6 +78,12 @@ int main(int argc, char **argv, char **envp) {
         fprintf(stderr, "ERROR: Could not load crash log file \"%s\".\n", [filepath UTF8String]);
         return 1;
     }
+    
+    CRException *exception = [report exception];
+    if ([[exception type] integerValue] == 20) {
+        //Simulated Crash No Need To Report
+        return 0;
+    }
 
     if (!isDebugMode) {
         // Check freshness of crash log.

--- a/notifier/main.m
+++ b/notifier/main.m
@@ -80,7 +80,7 @@ int main(int argc, char **argv, char **envp) {
     }
     
     CRException *exception = [report exception];
-    if ([[exception type] integerValue] == 20) {
+    if ([[exception type] isEqualToString:@"00000020"]) {
         //Simulated Crash No Need To Report
         return 0;
     }


### PR DESCRIPTION
Simulated crash reports are caused by long running tasks in the BG and do not actually cause apps to crash. There is not need to notify the user and in fact the notifications can be quite annoying.
